### PR TITLE
Treat empty resumption tokens as missing

### DIFF
--- a/modules/admin/app/services/harvesting/WSOaiPmhClient.scala
+++ b/modules/admin/app/services/harvesting/WSOaiPmhClient.scala
@@ -164,7 +164,7 @@ case class WSOaiPmhClient @Inject()(ws: WSClient)(implicit ec: ExecutionContext,
             val name = (node \ "identifier").text
             name -> del
           }
-          val next = (xml \ verb \ "resumptionToken").headOption.map(_.text)
+          val next = (xml \ verb \ "resumptionToken").headOption.map(_.text).filter(_.trim.nonEmpty)
 
           idents -> next
         }


### PR DESCRIPTION
Some implementations have an empty tag in the payload.