### PR TITLE
Ensure that metadata is signed when creating S3 upload URIs

### DIFF
--- a/modules/admin/app/assets/js/datasets/api.ts
+++ b/modules/admin/app/assets/js/datasets/api.ts
@@ -33,6 +33,7 @@ export class DatasetManagerApi {
 
   static DONE_MSG: string = "Done";
   static ERR_MSG: string = "Error";
+  private static SOURCE_META = 'user';
 
   constructor(service: object, repoId: string) {
     this.service = service;
@@ -89,6 +90,11 @@ export class DatasetManagerApi {
   }
 
   uploadHandle(ds: string, stage: string, fileSpec: FileToUpload): Promise<{presignedUrl: string}> {
+    // NB: Because we're adding the Amazon-specific headers in the `uploadFile` method,
+    // we need to make sure the 'source' metadata field is included in the upload handle request.
+    let meta = fileSpec.meta || {};
+    meta['source'] = DatasetManagerApi.SOURCE_META;
+    fileSpec.meta = meta;
     return apiCall(this.service.datasets.ImportFiles.uploadHandle(this.repoId, ds, stage), fileSpec);
   }
 
@@ -106,7 +112,7 @@ export class DatasetManagerApi {
       headers: {
         'Content-type': file.type,
         'Cache-Control': 120,
-        'x-amz-meta-source': 'user',
+        'x-amz-meta-source': DatasetManagerApi.SOURCE_META,
       },
       cancelToken: source.token,
     }).then(r => r.status === 200)

--- a/modules/admin/app/assets/js/datasets/components/_manager-upload.vue
+++ b/modules/admin/app/assets/js/datasets/components/_manager-upload.vue
@@ -121,7 +121,10 @@ export default {
         return Promise.reject(new UploadCancelled(file.name));
       }
 
-      return this.api.uploadHandle(this.datasetId, this.fileStage, _pick(file, ['name', 'type', 'size']))
+      let meta = {source: 'user'}; // This is necessary for the backend to accept the upload,
+                                   // and it must match the value used in the uploadFiles method
+      let fileSpec = {..._pick(file, ['name', 'type', 'size']), ...{meta: meta}};
+      return this.api.uploadHandle(this.datasetId, this.fileStage, fileSpec)
           .then(data => {
             let self = this;
             this.setUploadProgress(file, 0);

--- a/modules/admin/app/assets/js/datasets/components/_modal-ingest-config.vue
+++ b/modules/admin/app/assets/js/datasets/components/_modal-ingest-config.vue
@@ -61,7 +61,9 @@ export default {
       // the stage of the ingest manager ('output').
       try {
         this.loading = true;
-        let data = await this.api.uploadHandle(this.datasetId, this.config.config, _pick(file, ['name', 'type', 'size']))
+        let fileSpec = _pick(file, ['name', 'type', 'size']);
+        fileSpec['meta'] = {source: 'user'};
+        let data = await this.api.uploadHandle(this.datasetId, this.config.config, fileSpec)
         await this.api.uploadFile(data.presignedUrl, file, () => true);
         this.$emit("update");
         this.properties = file.name;

--- a/modules/admin/app/assets/js/datasets/types.ts
+++ b/modules/admin/app/assets/js/datasets/types.ts
@@ -135,6 +135,7 @@ export interface FileToUpload {
   name: string,
   type: string,
   size: number,
+  meta: Record<string, string>
 }
 
 export interface FileInfo {

--- a/modules/admin/app/controllers/datasets/ImportFiles.scala
+++ b/modules/admin/app/controllers/datasets/ImportFiles.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 
-case class FileToUpload(name: String, `type`: String, size: Long)
+case class FileToUpload(name: String, `type`: String, size: Long, meta: Map[String, String] = Map.empty)
 
 object FileToUpload {
   implicit val _json: Format[FileToUpload] = Json.format[FileToUpload]
@@ -146,7 +146,7 @@ case class ImportFiles @Inject()(
 
   def uploadHandle(id: String, ds: String, stage: FileStage.Value): Action[FileToUpload] = EditAction(id).apply(apiJson[FileToUpload]) { implicit request =>
     val path = s"${prefix(id, ds, stage)}${request.body.name}"
-    val url = storage.uri(path, contentType = Some(request.body.`type`))
+    val url = storage.uri(path, contentType = Some(request.body.`type`), meta = request.body.meta)
     Ok(Json.obj("presignedUrl" -> url))
   }
 

--- a/modules/portal/app/services/storage/FileStorage.scala
+++ b/modules/portal/app/services/storage/FileStorage.scala
@@ -57,7 +57,7 @@ trait FileStorage {
     * @param versionId   the version ID of the file content
     * @return the file URI of the stored file
     */
-  def uri(path: String, duration: FiniteDuration = 10.minutes, contentType: Option[String] = None, versionId: Option[String] = None): URI
+  def uri(path: String, duration: FiniteDuration = 10.minutes, contentType: Option[String] = None, versionId: Option[String] = None, meta: Map[String, String] = Map.empty): URI
 
   /**
     * Put a file object in storage.

--- a/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
+++ b/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
@@ -69,7 +69,7 @@ case class S3CompatibleFileStorage(
     .fold(clientBuilder)(url => clientBuilder.endpointOverride(URI.create(url)))
     .build()
 
-  override def uri(path: String, duration: FiniteDuration = 10.minutes, contentType: Option[String] = None, versionId: Option[String] = None): URI = {
+  override def uri(path: String, duration: FiniteDuration = 10.minutes, contentType: Option[String] = None, versionId: Option[String] = None, meta: Map[String, String] = Map.empty): URI = {
     val expire = java.time.Duration.ofNanos(duration.toNanos)
     val preSignerBuilder = S3Presigner.builder()
       .credentialsProvider(credentials)
@@ -80,6 +80,7 @@ case class S3CompatibleFileStorage(
     contentType.map { ct =>
       val r = PutObjectRequest.builder()
         .contentType(ct)
+        .metadata(meta.asJava)
         .bucket(name)
         .key(path)
         .build()

--- a/test/services/storage/MockFileStorage.scala
+++ b/test/services/storage/MockFileStorage.scala
@@ -105,7 +105,7 @@ case class MockFileStorage(name: String, db: collection.mutable.Map[String, Seq[
     else FileList(all, truncated = false)
   }(ec)
 
-  override def uri(key: String, duration: FiniteDuration = 10.minutes, contentType: Option[String], versionId: Option[String] = None): URI =
+  override def uri(key: String, duration: FiniteDuration = 10.minutes, contentType: Option[String], versionId: Option[String] = None, meta: Map[String, String] = Map.empty): URI =
     new URI(urlPrefix + key)
 
   override def deleteFiles(paths: String*): Future[Seq[String]] = Future {


### PR DESCRIPTION
Upgrading MinIO caused an error here, because we were passing metadata via headers that were not signed in the request.