### PR TITLE
Fix the function that infers parent identifiers from an ID

### DIFF
--- a/test/services/data/WsDataServiceSpec.scala
+++ b/test/services/data/WsDataServiceSpec.scala
@@ -48,7 +48,20 @@ class WsDataServiceSpec extends IntegrationTestRunner {
     }
   }
 
-  "RestBackend" should {
+  "WsDataService" should {
+    "infer parent IDs from an ID correctly" in {
+      WsDataService.parentIds("foo-bar-baz-spam-eggs") must_== Seq(
+        "foo",
+        "foo-bar",
+        "foo-bar-baz",
+        "foo-bar-baz-spam",
+      )
+
+      WsDataService.parentIds("foo-bar") must_== Seq("foo")
+
+      WsDataService.parentIds("foo") must_== Seq.empty[String]
+    }
+
     "allow fetching single objects" in new ITestApp {
       val test: TestResource = await(testBackend.get[TestResource]("c1"))
       test.id must equalTo("c1")


### PR DESCRIPTION
Pretty egregious that this was borked by including the ID itself in the list of parents.