### PR TITLE
Event stream persistence / replay

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,9 @@ val coreDependencies = backendDependencies ++ Seq(
   "org.playframework.anorm" %% "anorm" % "2.7.0",
   "org.playframework.anorm" %% "anorm-postgres" % "2.7.0",
 
+  // Time-based UUIDs
+  "com.github.f4b6a3" % "uuid-creator" % "6.1.1",
+
   // Commons IO
   "commons-io" % "commons-io" % "2.5",
 

--- a/conf/evolutions/default/1.sql
+++ b/conf/evolutions/default/1.sql
@@ -398,8 +398,19 @@ CREATE TABLE field_meta(
 CREATE INDEX field_meta_entity_type ON field_meta(entity_type);
 CREATE INDEX field_meta_id ON field_meta(id);
 
+CREATE TABLE application_event(
+    id      UUID NOT NULL PRIMARY KEY,
+    data    TEXT,
+    name    VARCHAR(50) NOT NULL,
+    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX application_event_id ON application_event(id);
+CREATE INDEX application_event_name ON application_event(name);
+
  # --- !Downs
 
+DROP TABLE IF EXISTS application_event CASCADE;
 DROP TABLE IF EXISTS field_meta CASCADE;
 DROP TABLE IF EXISTS entity_type_meta CASCADE;
 DROP TABLE IF EXISTS coreference CASCADE;

--- a/etc/db_migrations/20250926_add_application_event_tables.sql
+++ b/etc/db_migrations/20250926_add_application_event_tables.sql
@@ -1,0 +1,13 @@
+BEGIN TRANSACTION;
+
+CREATE TABLE application_event(
+    id      UUID NOT NULL PRIMARY KEY,
+    data    TEXT,
+    name    VARCHAR(50) NOT NULL,
+    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX application_event_id ON application_event(id);
+CREATE INDEX application_event_name ON application_event(name);
+
+COMMIT;

--- a/modules/admin/app/actors/ingest/DataImporter.scala
+++ b/modules/admin/app/actors/ingest/DataImporter.scala
@@ -90,8 +90,7 @@ case class DataImporter(
             }
           })
           .pipeTo(self)
-      }
-      else self ! sync.log
+      } else self ! sync.log
 
     case log: ImportLog =>
       msgTo ! log

--- a/modules/admin/app/controllers/admin/ServerSentEvents.scala
+++ b/modules/admin/app/controllers/admin/ServerSentEvents.scala
@@ -1,0 +1,80 @@
+package controllers.admin
+
+import controllers.AppComponents
+import controllers.admin.ServerSentEvents.LAST_EVENT_ID_HEADER
+import controllers.base.AdminController
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.stream.scaladsl.{BroadcastHub, Keep, Source}
+import org.apache.pekko.stream.{CompletionStrategy, Materializer, OverflowStrategy}
+import org.apache.pekko.{Done, NotUsed}
+import play.api.http.MimeTypes
+import play.api.libs.EventSource
+import play.api.mvc._
+import services.data.ApplicationEventServiceMediator.sseEvent
+import services.data.{EventForwarder, ApplicationEventService}
+
+import javax.inject._
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+object ServerSentEvents {
+  val LAST_EVENT_ID_HEADER = "Last-Event-Id"
+}
+
+/**
+  * Controller for Server-Sent Events (SSE) feeds.
+  */
+@Singleton
+case class ServerSentEvents @Inject()(
+  controllerComponents: ControllerComponents,
+  appComponents: AppComponents,
+  @Named("event-forwarder") forwarder: ActorRef,
+  eventStore: ApplicationEventService,
+  actorSystem: ActorSystem,
+)(implicit mat: Materializer) extends AdminController {
+
+  override val staffOnly = false
+
+  // keep-alive period for event stream
+  private val keepAlivePeriod: FiniteDuration = config.get[FiniteDuration]("ehri.eventStream.keepAlive")
+
+  // finish transmitting buffered elements after completion
+  private val completionMatcher: PartialFunction[Any, CompletionStrategy] = {
+    case Done => CompletionStrategy.draining
+  }
+
+  private val (handler: ActorRef, eventSource: Source[EventForwarder.Action, NotUsed]) = Source.actorRef[EventForwarder.Action](
+    completionMatcher = completionMatcher,
+    failureMatcher = PartialFunction.empty[Any, Throwable], // Never fail this stream
+    bufferSize = 100,
+    overflowStrategy = OverflowStrategy.dropTail)
+    .toMat(BroadcastHub.sink)(Keep.both)
+    .run()
+
+  // Subscribe to events...
+  forwarder ! EventForwarder.Subscribe(handler)
+
+
+  /**
+    * Add a Server-Send event feed of items created, updated or deleted
+    */
+  def lifecycle: Action[AnyContent] = Action { implicit request =>
+
+    // If we have a replay header, fetch an initial stream from the store
+    val lastInsertId: Option[String] = request.headers.get(LAST_EVENT_ID_HEADER).filter(_.trim.nonEmpty)
+    val replay: Future[Seq[EventSource.Event]] = lastInsertId.map { id =>
+      eventStore.get(id).map(_.map(ev => EventSource.Event(ev.data, id = Some(ev.id.toString), name = ev.name)))
+    }.getOrElse(Future.successful(Seq.empty[EventSource.Event]))
+    val replaySource = Source.futureSource(replay.map(Source.apply))
+
+    val events: Source[EventSource.Event, NotUsed] = eventSource.collect {
+      case ev: EventForwarder.Action => sseEvent(ev)
+    }.collect {
+      case Some(event) => event
+    }.keepAlive(keepAlivePeriod, () => EventSource.Event(""))
+
+    val stream = replaySource.concat(events)
+
+    Ok.chunked(stream).as(MimeTypes.EVENT_STREAM)
+  }
+}

--- a/modules/admin/app/controllers/admin/Utils.scala
+++ b/modules/admin/app/controllers/admin/Utils.scala
@@ -1,29 +1,17 @@
 package controllers.admin
 
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.stream.scaladsl.{BroadcastHub, Keep, Sink, Source}
-import org.apache.pekko.stream.{CompletionStrategy, Materializer, OverflowStrategy}
-import org.apache.pekko.{Done, NotUsed}
 import controllers.AppComponents
 import controllers.base.AdminController
-import models.EntityType
-import play.api.http.MimeTypes
-import play.api.libs.EventSource
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Sink
 import play.api.libs.json._
-import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.cypher.CypherService
-import services.data.{AuthenticatedUser, EventForwarder}
-import services.ingest.EadValidator
-import services.search.SearchIndexMediator
-import services.storage.FileStorage
+import services.data.AuthenticatedUser
 import utils.PageParams
 
-import java.time.Instant
-import java.util.UUID
 import javax.inject._
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
 
 
 /**
@@ -33,52 +21,10 @@ import scala.concurrent.duration.FiniteDuration
 case class Utils @Inject()(
   controllerComponents: ControllerComponents,
   appComponents: AppComponents,
-  searchIndexer: SearchIndexMediator,
-  ws: WSClient,
-  eadValidator: EadValidator,
   cypher: CypherService,
-  @Named("dam") storage: FileStorage,
-  @Named("event-forwarder") forwarder: ActorRef
 )(implicit mat: Materializer) extends AdminController {
 
   override val staffOnly = false
-
-  private val completionMatcher: PartialFunction[Any, CompletionStrategy] = {
-    case Done => CompletionStrategy.immediately
-  }
-
-  private val (handler: ActorRef, eventSource: Source[EventForwarder.Action, NotUsed]) = Source.actorRef[EventForwarder.Action](
-    completionMatcher = completionMatcher,
-    failureMatcher = PartialFunction.empty[Any, Throwable], // Never fail this stream
-    bufferSize = 100,
-    overflowStrategy = OverflowStrategy.dropTail)
-    .toMat(BroadcastHub.sink)(Keep.both)
-    .run()
-
-  // Subscribe to events...
-  forwarder ! EventForwarder.Subscribe(handler)
-
-  /**
-    * Add a Server-Send event feed of items created, updated or deleted
-    */
-  def sse: Action[AnyContent] = Action { implicit request =>
-    import services.data.EventForwarder._
-    val keepAlivePeriod = config.get[FiniteDuration]("ehri.eventStream.keepAlive")
-
-    def toPayload(items: Seq[(EntityType.Value, String)], name: String): EventSource.Event =
-      EventSource.Event(Json.stringify(
-        Json.obj("datetime" -> Instant.now(), "ids" -> items.map(_._2), "types" -> items.map(_._1.toString))),
-        name = Some(name),
-        id = Some(UUID.randomUUID().toString))
-
-    val events = eventSource.collect {
-      case Create(ids) if ids.nonEmpty => toPayload(ids, "create-event")
-      case Update(ids) if ids.nonEmpty => toPayload(ids, "update-event")
-      case Delete(ids) if ids.nonEmpty => toPayload(ids, "delete-event")
-    }.keepAlive(keepAlivePeriod, () => EventSource.Event(""))
-
-    Ok.chunked(events).as(MimeTypes.EVENT_STREAM)
-  }
 
   /** Check the database is up by trying to load the admin account.
     */

--- a/modules/admin/conf/admin.routes
+++ b/modules/admin/conf/admin.routes
@@ -36,7 +36,9 @@ GET         /metrics/_clear                     @controllers.admin.Metrics.clear
 # Monitoring
 GET         /monitor/_check                     @controllers.admin.Utils.checkServices()
 GET         /monitor/_checkUserSync             @controllers.admin.Utils.checkUserSync()
-GET         /monitor/_events                    @controllers.admin.Utils.sse()
+
+# Server-Sent events feeds
+GET         /monitor/_events                    @controllers.admin.ServerSentEvents.lifecycle()
 
 # API
 # Forward to any dataApi GET method

--- a/modules/backend/src/main/scala/services/data/EventHandler.scala
+++ b/modules/backend/src/main/scala/services/data/EventHandler.scala
@@ -1,11 +1,8 @@
 package services.data
 
 import models.EntityType
-import org.apache.pekko.actor.ActorRef
 
 trait EventHandler {
-  def subscribe(actorRef: ActorRef): Unit = ()
-  def unsubscribe(actorRef: ActorRef): Unit = ()
   def handleCreate(items: (EntityType.Value, String)*): Unit
   def handleUpdate(items: (EntityType.Value, String)*): Unit
   def handleDelete(items: (EntityType.Value, String)*): Unit

--- a/modules/backend/src/main/scala/services/data/WsDataService.scala
+++ b/modules/backend/src/main/scala/services/data/WsDataService.scala
@@ -1,9 +1,9 @@
 package services.data
 
+import models.{ContentTypes, EntityType, GlobalPermissionSet, ItemPermissionSet, Readable, Resource, WithId, Writable}
 import org.apache.pekko.Done
 import org.apache.pekko.stream.scaladsl.{JsonFraming, Source}
 import org.apache.pekko.util.ByteString
-import models.{ContentTypes, EntityType, GlobalPermissionSet, ItemPermissionSet, Readable, Resource, WithId, Writable}
 import play.api.Configuration
 import play.api.cache.AsyncCacheApi
 import play.api.http.{ContentTypeOf, HeaderNames, HttpVerbs, Status}

--- a/modules/backend/src/main/scala/utils/http/package.scala
+++ b/modules/backend/src/main/scala/utils/http/package.scala
@@ -3,6 +3,7 @@ package utils
 import org.apache.jena.iri.IRIFactory
 
 import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 package object http {
 
@@ -19,7 +20,7 @@ package object http {
     */
   def joinQueryString(qs: Seq[(String, String)]): String =
     qs.map { case (key, value) =>
-      URLEncoder.encode(key, "UTF-8") + "=" + URLEncoder.encode(value, "UTF-8")
+      URLEncoder.encode(key, StandardCharsets.UTF_8) + "=" + URLEncoder.encode(value, StandardCharsets.UTF_8)
     }.mkString("&")
 
   /**
@@ -53,6 +54,6 @@ package object http {
   def parseQueryString(s: String): Seq[(String, String)] = s.split('&')
     .map(_.split('=').toList)
     .collect { case key :: value :: Nil =>
-      URLDecoder.decode(key, "UTF-8") -> URLDecoder.decode(value, "UTF-8")
+      URLDecoder.decode(key, StandardCharsets.UTF_8) -> URLDecoder.decode(value, StandardCharsets.UTF_8)
     }.toSeq
 }

--- a/modules/core/src/main/scala/services/data/ApplicationEventService.scala
+++ b/modules/core/src/main/scala/services/data/ApplicationEventService.scala
@@ -1,0 +1,19 @@
+package services.data
+
+import com.google.inject.ImplementedBy
+
+import java.util.UUID
+import scala.concurrent.Future
+
+case class ApplicationEvent(id: UUID, data: String, name: Option[String])
+
+/**
+  * Service that stores events and facilitates retrieval by last-insert-id.
+  */
+@ImplementedBy(classOf[SqlApplicationEventService])
+trait ApplicationEventService {
+
+  def save(events: Seq[ApplicationEvent]): Future[Int]
+
+  def get(lastInsertId: String): Future[Seq[ApplicationEvent]]
+}

--- a/modules/core/src/main/scala/services/data/ApplicationEventServiceMediator.scala
+++ b/modules/core/src/main/scala/services/data/ApplicationEventServiceMediator.scala
@@ -1,0 +1,76 @@
+package services.data
+
+import models.EntityType
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef}
+import play.api.libs.EventSource
+import play.api.libs.json.Json
+import services.data.EventForwarder.{Create, Delete, Update}
+
+import java.time.Instant
+import java.util.UUID
+import javax.inject.{Inject, Named, Singleton}
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+object ApplicationEventServiceMediator {
+
+  private case class Stored(count: Int)
+
+  val CREATE_EVENT = "create-event"
+  val UPDATE_EVENT = "update-event"
+  val DELETE_EVENT = "delete-event"
+
+  // Generate a Server-Send Events (SSE) payload...
+  private def toPayload(items: Seq[(EntityType.Value, String)], uuid: UUID, name: String): EventSource.Event = EventSource.Event(
+    Json.stringify(Json.obj("datetime" -> Instant.now(), "ids" -> items.map(_._2), "types" -> items.map(_._1))),
+    id = Some(uuid.toString),
+    name = Some(name),
+  )
+
+  /**
+    * Convert an action from the event forwarder, to an SSE payload.
+    */
+  def sseEvent(ev: EventForwarder.Action): Option[EventSource.Event] = ev match {
+    case Create(items, uuid) if items.nonEmpty => Some(toPayload(items, uuid, CREATE_EVENT))
+    case Update(items, uuid) if items.nonEmpty => Some(toPayload(items, uuid, UPDATE_EVENT))
+    case Delete(items, uuid) if items.nonEmpty => Some(toPayload(items, uuid, DELETE_EVENT))
+    case _ => None
+  }
+}
+
+/**
+  * This actor subscribes to the Event Feed on construction and
+  * stores any events received in the event store.
+  *
+  * @param eventService the application event service
+  * @param forwarder    the event feed actor
+  */
+@Singleton
+class ApplicationEventServiceMediator @Inject()(
+  eventService: ApplicationEventService,
+  @Named("event-forwarder") forwarder: ActorRef
+)(implicit ec: ExecutionContext) extends Actor with ActorLogging {
+
+  import ApplicationEventServiceMediator._
+  import org.apache.pekko.pattern.pipe
+
+  // When we get constructed, subscribe to the EventForwarder's event feed...
+  forwarder ! EventForwarder.Subscribe(self)
+
+  override def receive: Receive = {
+    case ev: EventForwarder.Action =>
+      log.debug("Received an action: {}", ev)
+      sseEvent(ev).map { event =>
+        eventService.save(Seq(ApplicationEvent(id = ev.uuid, event.data, name = event.name)))
+          .map(Stored)
+          .pipeTo(self)
+          .onComplete {
+            case Failure(exception) => log.error(exception, s"Error storing event: $ev")
+            case Success(Stored(count)) => log.debug("Event successfully stored (count: {}): {}", count, ev)
+          }
+      }
+
+    case Stored(count) =>
+      log.debug("Stored {} events", count)
+  }
+}

--- a/modules/core/src/main/scala/services/data/EventForwarder.scala
+++ b/modules/core/src/main/scala/services/data/EventForwarder.scala
@@ -1,8 +1,10 @@
 package services.data
 
+import com.github.f4b6a3.uuid.alt.GUID
 import models.EntityType
 import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Terminated}
 
+import java.util.UUID
 import javax.inject.Inject
 
 object EventForwarder {
@@ -11,36 +13,42 @@ object EventForwarder {
 
   sealed trait Action {
     def items: Seq[(EntityType.Value, String)]
+    def uuid: UUID
   }
-  case class Create(items: Seq[(EntityType.Value, String)]) extends Action
-  case class Update(items: Seq[(EntityType.Value, String)]) extends Action
-  case class Delete(items: Seq[(EntityType.Value, String)]) extends Action
+  case class Create(items: Seq[(EntityType.Value, String)], uuid: UUID = GUID.v7().toUUID) extends Action
+  case class Update(items: Seq[(EntityType.Value, String)], uuid: UUID = GUID.v7().toUUID) extends Action
+  case class Delete(items: Seq[(EntityType.Value, String)], uuid: UUID = GUID.v7().toUUID) extends Action
 }
 
-class EventForwarder @Inject() () extends Actor with ActorLogging {
+class EventForwarder @Inject() extends Actor with ActorLogging {
   import EventForwarder._
 
   def forward(subs: Set[ActorRef]): Receive = {
     case Subscribe(sub) =>
+      log.debug("Subscribed {}", sub)
       context.watch(sub)
       context.become(forward(subs + sub))
 
     case Unsubscribe(sub) =>
+      log.debug("Unsubscribed {}", sub)
       context.unwatch(sub)
       context.become(forward(subs - sub))
 
     case Terminated(sub) =>
+      log.debug("Terminated {}", sub)
       context.unwatch(sub)
       context.become(forward(subs - sub))
 
-    case msg => subs.foreach(_ ! msg)
+    case msg =>
+      subs.foreach(_ ! msg)
   }
 
   def receive: Receive = {
     // If we're here we don't have any subscribers yet, so
     // nothing to do unless we receive an actor...
     case Subscribe(sub) =>
-      context.become(forward(Set(sub)))
+      context.become(forward(Set.empty))
+      self ! Subscribe(sub)
   }
 }
 

--- a/modules/core/src/main/scala/services/data/SqlApplicationEventService.scala
+++ b/modules/core/src/main/scala/services/data/SqlApplicationEventService.scala
@@ -1,0 +1,49 @@
+package services.data
+
+import anorm.{BatchSql, Macro, NamedParameter, RowParser, SqlStringInterpolation}
+import org.apache.pekko.actor.ActorSystem
+import play.api.Configuration
+import play.api.db.Database
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+case class SqlApplicationEventService @Inject()(db: Database, config: Configuration)(implicit actorSystem: ActorSystem) extends ApplicationEventService {
+
+  private implicit def executionContext: ExecutionContext = actorSystem.dispatchers.lookup("contexts.db-writes")
+
+  private implicit val parser: RowParser[ApplicationEvent] = Macro.parser[ApplicationEvent]("id", "data", "name")
+
+  override def save(events: Seq[ApplicationEvent]): Future[Int] = Future {
+    db.withTransaction { implicit conn =>
+      val q =
+        """INSERT INTO application_event (id, data, name)
+           VALUES ({id}::UUID, {data}, {name})
+           ON CONFLICT DO NOTHING
+           """
+
+      if (events.nonEmpty) {
+        val inserts = events.map { r =>
+          Seq[NamedParameter](
+            "id" -> r.id,
+            "data" -> r.data,
+            "name" -> r.name,
+          )
+        }
+
+        BatchSql(q, inserts.head, inserts.tail: _*).execute().sum
+      } else 0
+    }
+  }
+
+  override def get(lastInsertId: String): Future[Seq[ApplicationEvent]] = Future {
+    db.withConnection { implicit conn =>
+      SQL"""
+           SELECT *
+           FROM application_event
+           WHERE id::varchar >= $lastInsertId
+             AND EXISTS (SELECT 1 FROM application_event WHERE id::varchar = $lastInsertId)
+           ORDER BY id ASC""".as(parser.*)
+    }
+  }
+}

--- a/modules/portal/app/guice/AppModule.scala
+++ b/modules/portal/app/guice/AppModule.scala
@@ -61,5 +61,6 @@ class AppModule extends AbstractModule with PekkoGuiceSupport {
     bind(classOf[ItemLifecycle]).to(classOf[GeocodingItemLifecycle])
     bind(classOf[GeocodingService]).toProvider(classOf[AwsGeocodingServiceProvider])
     bindActor[EventForwarder]("event-forwarder")
+    bindActor[ApplicationEventServiceMediator]("event-store-mediator")
   }
 }

--- a/test/helpers/TestConfiguration.scala
+++ b/test/helpers/TestConfiguration.scala
@@ -128,7 +128,7 @@ trait TestConfiguration {
     )
     .overrides(testSearchComponents: _*)
 
-  // Might want to mock the dataApi at at some point!
+  // Might want to mock the dataApi at some point!
   protected def dataApi(implicit app: play.api.Application, apiUser: DataUser, executionContext: ExecutionContext): DataService =
     app.injector.instanceOf[DataServiceBuilder].withContext(apiUser)(executionContext)
 

--- a/test/integration/admin/ServerSentEventsSpec.scala
+++ b/test/integration/admin/ServerSentEventsSpec.scala
@@ -1,0 +1,62 @@
+package integration.admin
+
+import com.github.f4b6a3.uuid.alt.GUID
+import helpers._
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Sink
+import play.api.Application
+import play.api.http.MimeTypes
+import play.api.libs.ws.ahc.StandaloneAhcWSClient
+import services.data.{ApplicationEventService, ApplicationEvent}
+
+/**
+ * Spec to test various page views operate as expected.
+ */
+class ServerSentEventsSpec extends IntegrationTestRunner with FakeMultipartUpload {
+
+  override def getConfig: Map[String, Any] =
+    super.getConfig ++ Map("ehri.eventStream.keepAlive" -> "10 millis")
+
+  "Server-Sent Events" should {
+
+    def client(implicit app: Application) = {
+      implicit val mat: Materializer = app.injector.instanceOf[Materializer]
+      StandaloneAhcWSClient()
+    }
+
+    "check event stream connects and sends keep-alive events" in new ITestServer() {
+      val req = client.url(s"http://localhost:${this.port}${controllers.admin.routes.ServerSentEvents.lifecycle()}")
+        .withHttpHeaders("Accept" -> "text/event-stream")
+        .stream()
+
+      val resp = await(req)
+      resp.status must_== OK
+      resp.contentType must_== "text/event-stream"
+
+      val events: Seq[String] = await(resp.bodyAsSource.take(3).map(_.utf8String).runWith(Sink.seq))
+      events.head must contain("data:")
+    }
+
+    "check event stream supports replay" in new ITestServer() {
+      val eventStore = app.injector.instanceOf[ApplicationEventService]
+      private val ids = 1.to(3).map(_ => GUID.v7().toUUID)
+      await(eventStore.save(
+        ids.map(id => ApplicationEvent(id, "test", Some("hello-world")))
+      ))
+
+      val req = client.url(s"http://localhost:${this.port}${controllers.admin.routes.ServerSentEvents.lifecycle()}")
+        .withHttpHeaders("Accept" -> MimeTypes.EVENT_STREAM)
+        .withHttpHeaders("Last-Event-Id" -> ids.head.toString)
+        .stream()
+
+      val resp = await(req)
+      resp.status must_== OK
+      resp.contentType must_== MimeTypes.EVENT_STREAM
+
+      val events: Seq[String] = await(resp.bodyAsSource.take(6).map(_.utf8String).runWith(Sink.seq))
+      events.head must contain("data: test")
+      events.head must contain(s"event: hello-world")
+      events.head must contain(s"id: ${ids.head}")
+    }
+  }
+}

--- a/test/integration/admin/UtilsSpec.scala
+++ b/test/integration/admin/UtilsSpec.scala
@@ -1,10 +1,6 @@
 package integration.admin
 
 import helpers._
-import org.apache.pekko.stream.Materializer
-import org.apache.pekko.stream.scaladsl.Sink
-import play.api.Application
-import play.api.libs.ws.ahc.StandaloneAhcWSClient
 import play.api.test.FakeRequest
 
 /**
@@ -12,15 +8,7 @@ import play.api.test.FakeRequest
  */
 class UtilsSpec extends IntegrationTestRunner with FakeMultipartUpload {
 
-  override def getConfig: Map[String, Any] =
-    super.getConfig ++ Map("ehri.eventStream.keepAlive" -> "10 millis")
-
   "Utils" should {
-
-    def client(implicit app: Application) = {
-      implicit val mat: Materializer = app.injector.instanceOf[Materializer]
-      StandaloneAhcWSClient()
-    }
 
     "return a successful ping of the EHRI REST service and search engine" in new ITestApp {
       val ping = FakeRequest(controllers.admin.routes.Utils.checkServices()).call()
@@ -35,20 +23,6 @@ class UtilsSpec extends IntegrationTestRunner with FakeMultipartUpload {
       // graph DB fixtures, so the sync check should (correctly)
       // highlight this.
       contentAsString(check) must contain("joeblogs")
-    }
-
-
-    "check event stream connects and sends keep-alive events" in new ITestServer() {
-      val req = client.url(s"http://localhost:${this.port}${controllers.admin.routes.Utils.sse()}")
-        .withHttpHeaders("Accept" -> "text/event-stream")
-        .stream()
-
-      val resp = await(req)
-      resp.status must_== OK
-      resp.contentType must_== "text/event-stream"
-
-      val events: Seq[String] = await(resp.bodyAsSource.take(3).map(_.utf8String).runWith(Sink.seq))
-      events.head must contain("data:")
     }
   }
 }


### PR DESCRIPTION
Add persistence for application events, streamed via `/admin/monitor/_events` SSE feed. This allows replay via `lastId`.