### PR TITLE
NOT FOR MERGING: Update the BaseX query processor to 9.7.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -367,7 +367,7 @@ lazy val xquery = Project(appName + "-xquery", file("modules/xquery"))
     "ch.qos.logback" % "logback-classic" % "1.5.6",
 
     // EAD transformation...
-    "org.basex" % "basex" % "8.5",
+    "org.basex" % "basex" % "10.7",
 
     // Command line parsing
     "com.github.scopt" %% "scopt" % "4.1.0",

--- a/modules/xquery/src/main/resources/transform.xqy
+++ b/modules/xquery/src/main/resources/transform.xqy
@@ -2,6 +2,13 @@ xquery version "3.1" encoding "UTF-8";
 
 declare namespace xquery="http://basex.org/modules/xquery";
 declare namespace csv="http://basex.org/modules/csv";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+
+(: Set the indentation on :)
+declare option output:indent "yes";
+
+(: BaseX-specific option for indent size (default is 2) :)
+declare option output:indents "4";
 
 (: make children for the given target path in the configuration :)
 (: $target-path: the target path for which to make children as in the configuration :)


### PR DESCRIPTION
This version includes a useful strip-namespaces function.

Upgrading to version 11.x throws SAX errors due to incompatibilities with the underlying processor, which can be investigated later.

Upgrading to 12.x requires Java 17