### PR TITLE
Add a util function to strip namespaces from serialized elements

### DIFF
--- a/modules/xquery/src/main/resources/xtra.xqm
+++ b/modules/xquery/src/main/resources/xtra.xqm
@@ -271,3 +271,13 @@ declare function xtra:language-name-to-code($name as xs:string) as xs:string {
       then map:get($xtra:langs, $name)
       else $name
 };
+
+declare function xtra:strip-namespaces($item as item()*) as item()* {
+  typeswitch ($item)
+    case element() return
+      element {fn:QName((), fn:local-name($item))} {
+        $item/@*,
+        $item/node() ! xtra:strip-namespaces(.)
+      }
+    default return $item
+};


### PR DESCRIPTION
This is useful for some terrible hacks being committed for data import.