### PR TITLE
Allow the coreference manager to extract authorities...

### DIFF
--- a/modules/admin/app/controllers/datasets/CoreferenceTables.scala
+++ b/modules/admin/app/controllers/datasets/CoreferenceTables.scala
@@ -49,7 +49,7 @@ case class CoreferenceTables @Inject()(
          MATCH (:Repository {__id:$scope})
             <-[:heldBy|childOf*]-(:DocumentaryUnit)
             <-[:describes]-(:DocumentaryUnitDescription)-[:relatesTo]->(ap:AccessPoint)
-            <-[:hasLinkBody]-(:Link)-[:hasLinkTarget]->(c:CvocConcept)-[:inAuthoritativeSet]->(s:CvocVocabulary)
+            <-[:hasLinkBody]-(:Link)-[:hasLinkTarget]->(c)-[:inAuthoritativeSet]->(s)
          RETURN DISTINCT ap.name as text, c.__id as target, s.__id as set
         """
     for {

--- a/test/integration/admin/CoreferenceTablesSpec.scala
+++ b/test/integration/admin/CoreferenceTablesSpec.scala
@@ -34,11 +34,10 @@ class CoreferenceTablesSpec extends IntegrationTestRunner with ResourceUtils {
     }
 
     "extract tables" in new DBTestApp("coreference-fixtures.sql") {
-      // FIXME: current Neo4j fixtures don't exercise this test!
       val r = FakeRequest(routes.extractTable("r1"))
         .withUser(privilegedUser)
         .call()
-      contentAsJson(r) must_== Json.obj("imported" -> 0)
+      contentAsJson(r) must_== Json.obj("imported" -> 2)
     }
 
     "ingest tables" in new DBTestApp("coreference-fixtures.sql") {


### PR DESCRIPTION
... in addition to concepts (subjects etc)

IIRC, this was not done initially because the original use-case was connecting items using external controlled vocabularies at import time (e.g. USHMM LCSH). However, it turns out the coreference table is useful for transferring links between e.g. production and staging, and I can't think of any downsides to enabling connecting of authorities as well.