### PR TITLE
Fix an issue where URLs would get mangled

### DIFF
--- a/modules/backend/src/main/scala/utils/http/package.scala
+++ b/modules/backend/src/main/scala/utils/http/package.scala
@@ -9,7 +9,7 @@ package object http {
   import java.net.URLEncoder
 
   def joinPath(path: String, qs: Map[String, Seq[String]]): String =
-    List(path, joinQueryString(qs)).filter(_.trim.nonEmpty).mkString("?")
+    List(path.takeWhile(_ != '?'), joinQueryString(qs)).filter(_.trim.nonEmpty).mkString("?")
 
   /**
     * Turn a seq of parameters into an URL parameter string, not including

--- a/modules/backend/src/test/scala/utils/http/HttpSpec.scala
+++ b/modules/backend/src/test/scala/utils/http/HttpSpec.scala
@@ -12,5 +12,10 @@ class HttpSpec extends PlaySpecification {
       val iri = "https://example.com/test/בדיקה"
       iriToUri(iri) must_== "https://example.com/test/%D7%91%D7%93%D7%99%D7%A7%D7%94"
     }
+    "join paths correctly" in {
+      val qs = Map("dlid" -> Seq("eng"))
+      joinPath("/foo/bar/baz", qs) must_== "/foo/bar/baz?dlid=eng"
+      joinPath("/foo/bar/baz?dlid=eng", qs) must_== "/foo/bar/baz?dlid=eng"
+    }
   }
 }


### PR DESCRIPTION
This was due to passing in a request path including a query string, and then appending a query string.

Fixes #1614
