### PR TITLE
Attempt some tweaks to the robots.txt

### DIFF
--- a/modules/portal/public/robots.txt
+++ b/modules/portal/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
+Content-signal: search=yes, ai-train=no, ai-input=yes
 Disallow: /people/
 Disallow: /profile/
 Disallow: /admin/
@@ -10,8 +11,5 @@ Disallow: /locale
 Disallow: /feedback/
 Disallow: /activity
 Disallow: /api/datasets
-Disallow: /guides
-Disallow: */export
-
-User-agent: GPTBot
-Disallow: /
+Disallow: /*/export
+Crawl-delay: 5


### PR DESCRIPTION
Try and prevent crawling for AI training, though obviously this won't actually work.

Remove explicit bot mentions, since most are banned via Apache policy anyway.