### PR TITLE
Fix completely backward logic on harvester delay.

### DIFF
--- a/modules/admin/app/actors/harvesting/ResourceSyncHarvester.scala
+++ b/modules/admin/app/actors/harvesting/ResourceSyncHarvester.scala
@@ -73,7 +73,7 @@ case class ResourceSyncHarvester (client: ResourceSyncClient, storage: FileStora
       copyItem(job, item).flatMap { case (name, isFresh) =>
         msgTo ! DoneFile(name)
         val res = Fetch(rest, count + 1, if (isFresh) fresh + 1 else fresh)
-        val delay = if (isFresh) None else job.data.config.delay
+        val delay = if (isFresh) job.data.config.delay else None
         delayIf(delay, res)
       }.pipeTo(self)
 

--- a/modules/admin/app/actors/harvesting/UrlSetHarvester.scala
+++ b/modules/admin/app/actors/harvesting/UrlSetHarvester.scala
@@ -68,7 +68,7 @@ case class UrlSetHarvester (client: WSClient, storage: FileStorage)(
       copyItem(job, item).flatMap { case (name, isFresh) =>
         msgTo ! DoneFile(name)
         val res = Fetch(rest, count + 1, if (isFresh) fresh + 1 else fresh)
-        val delay = if (isFresh) None else job.data.config.delay
+        val delay = if (isFresh) job.data.config.delay else None
         delayIf(delay, res)
       }.pipeTo(self)
 


### PR DESCRIPTION
This only activated the delay when the file *wasn't* downloaded. Doh!