### PR TITLE
Make backend batch endpoints consistently emit events

### DIFF
--- a/modules/admin/app/actors/cleanup/CleanupRunner.scala
+++ b/modules/admin/app/actors/cleanup/CleanupRunner.scala
@@ -4,7 +4,7 @@ import actors.Ticker
 import models.EntityType
 import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
 import play.api.Configuration
-import services.data.{DataService, EventForwarder}
+import services.data.DataService
 import services.ingest.{Cleanup, ImportLogService, IngestService}
 
 import java.time.Instant
@@ -42,7 +42,6 @@ case class CleanupRunner(
   dataApi: DataService,
   logService: ImportLogService,
   importService: IngestService,
-  eventForwarder: ActorRef
 )(implicit config: Configuration, ec: ExecutionContext) extends Actor with ActorLogging {
 
   import CleanupRunner._
@@ -90,10 +89,9 @@ case class CleanupRunner(
       ticker ! (msgTo -> "Deleting...")
 
       val (batch, rest) = todo.splitAt(batchSize)
-      dataApi.batchDelete(batch, Some(job.repoId), logMsg = job.msg,
+      dataApi.batchDelete(EntityType.DocumentaryUnit, batch, Some(job.repoId), logMsg = job.msg,
           version = true, tolerant = true, commit = true)
         .map { batchCount =>
-          eventForwarder ! EventForwarder.Delete(batch.map(EntityType.DocumentaryUnit -> _))
           val st = newStatus.copy(deleteCount = newStatus.deleteCount + batchCount)
           msgTo ! st
           DeleteBatch(cleanup, rest, st)

--- a/modules/admin/app/controllers/countries/Countries.scala
+++ b/modules/admin/app/controllers/countries/Countries.scala
@@ -245,7 +245,7 @@ case class Countries @Inject()(
           )
         )
 
-        userDataApi.batchUpdate(data, Some(id), version = true, commit = true,
+        userDataApi.batchUpdate(EntityType.Repository, data, Some(id), version = true, commit = true,
               logMsg = "Update geographical info").map { done =>
             val msg = s"Finished Geocoding: $id: ${done.updated} updated, ${done.unchanged} unchanged"
             chan ! msg

--- a/modules/admin/app/controllers/datasets/ImportLogs.scala
+++ b/modules/admin/app/controllers/datasets/ImportLogs.scala
@@ -2,17 +2,16 @@ package controllers.datasets
 
 import actors.cleanup.CleanupRunner.CleanupJob
 import actors.cleanup.{CleanupRunner, CleanupRunnerManager}
-import org.apache.pekko.actor.{ActorContext, ActorRef, Props}
-import org.apache.pekko.stream.Materializer
-import org.apache.pekko.stream.scaladsl.Source
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic._
 import models._
+import org.apache.pekko.actor.{ActorContext, Props}
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
 import play.api.libs.json.{Format, JsString, Json, Reads}
 import play.api.mvc._
 import services.cypher.CypherService
-import services.data.EventForwarder
 import services.ingest.{ImportLogService, IngestService}
 import services.storage.FileStorage
 
@@ -41,7 +40,6 @@ object CleanupSummary {
 case class ImportLogs @Inject()(
   controllerComponents: ControllerComponents,
   @Named("dam") storage: FileStorage,
-  @Named("event-forwarder") eventForwarder: ActorRef,
   appComponents: AppComponents,
   importLogService: ImportLogService,
   cypherServer: CypherService,
@@ -111,7 +109,7 @@ case class ImportLogs @Inject()(
     val maxDeletions = config.get[Int]("ehri.admin.bulkOperations.maxDeletions")
     def deleteBatches(ids: Seq[String]): Future[Int] = {
       val (batch, rest) = ids.splitAt(maxDeletions)
-      userDataApi.batchDelete(batch, Some(id), logMsg = request.body.msg,
+      userDataApi.batchDelete(EntityType.DocumentaryUnit, batch, Some(id), logMsg = request.body.msg,
           version = true, tolerant = true, commit = true).flatMap { count =>
         if (rest.isEmpty) Future.successful(count)
         else deleteBatches(rest).map(_ + count)
@@ -126,7 +124,6 @@ case class ImportLogs @Inject()(
       redirectCount <- importService.remapMovedUnits(EntityType.DocumentaryUnit, cleanup.redirects)
       _ = logger.info(s"Done redirects: $redirectCount")
       delCount <- deleteBatches(cleanup.deletions)
-      _ = eventForwarder ! EventForwarder.Delete(cleanup.deletions.map(EntityType.DocumentaryUnit -> _))
       _ = logger.info(s"Done deletions: $delCount")
       _ <- importLogService.saveCleanup(id, snapshotId, cleanup)
     } yield {
@@ -143,7 +140,7 @@ case class ImportLogs @Inject()(
     logger.info(s"Starting async cleanup for repository $id, snapshot $snapshotId")
     val jobId = UUID.randomUUID().toString
     val job = CleanupJob(id, snapshotId, jobId, request.body.msg)
-    val init = (context: ActorContext) => context.actorOf(Props(CleanupRunner(userDataApi, importLogService, importService, eventForwarder)))
+    val init = (context: ActorContext) => context.actorOf(Props(CleanupRunner(userDataApi, importLogService, importService)))
     mat.system.actorOf(Props(CleanupRunnerManager(job, init)), jobId)
 
     Ok(Json.obj(

--- a/modules/admin/app/controllers/tools/Tools.scala
+++ b/modules/admin/app/controllers/tools/Tools.scala
@@ -4,7 +4,6 @@ import controllers.base.AdminController
 import controllers.{AppComponents, Execution}
 import models.{BatchDeleteTask, ContentTypes, EntityType}
 import org.apache.pekko.NotUsed
-import org.apache.pekko.actor.ActorRef
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.connectors.csv.scaladsl.CsvParsing
 import org.apache.pekko.stream.scaladsl.{FileIO, Flow, Sink, Source}
@@ -18,14 +17,13 @@ import play.api.libs.streams.Accumulator
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.cypher.CypherService
-import services.data.EventForwarder.{Create, Delete, Update}
 import services.data.InputDataError
 import services.ingest.{EadValidator, RemappingPrefixes, XmlValidationError}
 import services.search.SearchIndexMediator
 import utils.EnumUtils
 
 import java.nio.charset.StandardCharsets
-import javax.inject.{Inject, Named, Singleton}
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 import scala.concurrent.Future.{successful => immediate}
 
@@ -40,7 +38,6 @@ case class Tools @Inject()(
   ws: WSClient,
   cypher: CypherService,
   eadValidator: EadValidator,
-  @Named("event-forwarder") eventForwarder: ActorRef,
   urlPrefixes: RemappingPrefixes
 )(implicit mat: Materializer) extends AdminController {
 
@@ -116,7 +113,7 @@ case class Tools @Inject()(
         errForm => immediate(BadRequest(views.html.admin.tools.movedItemsForm(errForm,
           controllers.tools.routes.Tools.addMovedItemsPost()))),
         ct => request.body.file("csv").map { file =>
-          updateFromCsv(ct, FileIO.fromPath(file.ref.path))
+          addUrlRedirectsFromCsv(ct, FileIO.fromPath(file.ref.path))
             .map(newUrls => Ok(views.html.admin.tools.movedItemsAdded(newUrls)))
         }.getOrElse {
           immediate(Ok(views.html.admin.tools.movedItemsForm(
@@ -140,17 +137,18 @@ case class Tools @Inject()(
         ct => request.body.file("csv").filter(_.filename.nonEmpty).map { file =>
           parseCsv(FileIO.fromPath(file.ref.path))
             .collect { case from :: to :: _ => from -> to }
-            .runWith(Sink.seq).flatMap { todo =>
-            userDataApi.rename(todo).flatMap { items =>
-              updateFromCsv(ct, items)
-                .map(newUrls => Ok(views.html.admin.tools.movedItemsAdded(newUrls)))
-            } recover {
-              case e: InputDataError =>
-                BadRequest(views.html.admin.tools.renameItemsForm(
-                  boundForm.withGlobalError(e.details),
-                  controllers.tools.routes.Tools.renameItemsPost()))
+            .runWith(Sink.seq)
+            .flatMap { todo =>
+              userDataApi.rename(entityType(ct), todo).flatMap { items =>
+                addUrlRedirectsForType(ct, items)
+                  .map(newUrls => Ok(views.html.admin.tools.movedItemsAdded(newUrls)))
+              } recover {
+                case e: InputDataError =>
+                  BadRequest(views.html.admin.tools.renameItemsForm(
+                    boundForm.withGlobalError(e.details),
+                    controllers.tools.routes.Tools.renameItemsPost()))
+              }
             }
-          }
         }.getOrElse {
           immediate(BadRequest(views.html.admin.tools.renameItemsForm(
             boundForm.withGlobalError("No CSV file found"),
@@ -174,16 +172,16 @@ case class Tools @Inject()(
           parseCsv(FileIO.fromPath(file.ref.path))
             .collect { case id :: parent :: _ => id -> parent }
             .runWith(Sink.seq).flatMap { todo =>
-            userDataApi.reparent(todo, commit = true).flatMap { items =>
-              updateFromCsv(ct, items)
-                .map(newUrls => Ok(views.html.admin.tools.movedItemsAdded(newUrls)))
-            } recover {
-              case e: InputDataError =>
-                BadRequest(views.html.admin.tools.reparentItemsForm(
-                  boundForm.withGlobalError(e.details),
-                  controllers.tools.routes.Tools.reparentItemsPost()))
+              userDataApi.reparent(entityType(ct), todo, commit = true).flatMap { items =>
+                addUrlRedirectsForType(ct, items)
+                  .map(newUrls => Ok(views.html.admin.tools.movedItemsAdded(newUrls)))
+              } recover {
+                case e: InputDataError =>
+                  BadRequest(views.html.admin.tools.reparentItemsForm(
+                    boundForm.withGlobalError(e.details),
+                    controllers.tools.routes.Tools.reparentItemsPost()))
+              }
             }
-          }
         }.getOrElse {
           immediate(BadRequest(views.html.admin.tools.reparentItemsForm(
             boundForm.withGlobalError("No CSV file found"),
@@ -243,7 +241,7 @@ case class Tools @Inject()(
 
   def regenerateIdsForScope(ct: ContentTypes.Value, id: String, tolerant: Boolean): Action[AnyContent] = AdminAction.async { implicit request =>
     if (isAjax) {
-      userDataApi.regenerateIdsForScope(id, tolerant).map { items =>
+      userDataApi.regenerateIdsForScope(entityType(ct), id, tolerant).map { items =>
         Ok(views.html.admin.tools.regenerateIdsForm(regenerateIdsForm
           .fill(value = (ct, items.map { case (f, t) => (f, t, true) })),
           controllers.tools.routes.Tools.regenerateIdsPost(tolerant)))
@@ -262,8 +260,8 @@ case class Tools @Inject()(
         case (ct, items) =>
           val activeIds = items.collect { case (f, _, true) => f }
           logger.info(s"Renaming: $activeIds")
-          userDataApi.regenerateIds(activeIds, tolerant, commit = true).flatMap { items =>
-            updateFromCsv(ct, items)
+          userDataApi.regenerateIds(entityType(ct), activeIds, tolerant, commit = true).flatMap { items =>
+            addUrlRedirectsForType(ct, items)
               .map(newUrls => Ok(views.html.admin.tools.movedItemsAdded(newUrls)))
           }
       }
@@ -288,25 +286,22 @@ case class Tools @Inject()(
       ),
       task => userDataApi.findReplace(
         task.parentType, task.subType, task.property, task.find,
-        task.replace, commit, task.log).flatMap { found =>
+        task.replace, commit, task.log).map { found =>
         if (commit) {
-          val parentIds = found.map(_._1)
-          eventForwarder ! Update(parentIds.map(entityType(task.parentType) -> _))
-          indexer.indexIds(parentIds: _*).map { _ =>
-            Redirect(controllers.tools.routes.Tools.findReplace())
-              .flashing("success" -> Messages("admin.utils.findReplace.done", found.size))
-          }
+          Redirect(controllers.tools.routes.Tools.findReplace())
+            .flashing("success" -> Messages("admin.utils.findReplace.done", found.size))
+        } else {
+          Ok(views.html.admin.tools.findReplace(boundForm, Some(found),
+            controllers.tools.routes.Tools.findReplacePost(),
+            controllers.tools.routes.Tools.findReplacePost(commit = true)))
         }
-        else immediate(Ok(views.html.admin.tools.findReplace(boundForm, Some(found),
-          controllers.tools.routes.Tools.findReplacePost(),
-          controllers.tools.routes.Tools.findReplacePost(commit = true))))
       }
     )
   }
 
   def batchDelete: Action[AnyContent] = AdminAction.apply { implicit request =>
     Ok(views.html.admin.tools.batchDelete(BatchDeleteTask
-        .form.fill(BatchDeleteTask(EntityType.DocumentaryUnit)),
+      .form.fill(BatchDeleteTask(EntityType.DocumentaryUnit)),
       controllers.tools.routes.Tools.batchDeletePost()))
   }
 
@@ -316,19 +311,14 @@ case class Tools @Inject()(
       err => immediate(BadRequest(views.html.admin.tools.batchDelete(err,
         controllers.tools.routes.Tools.batchDeletePost()))),
       data => userDataApi.batchDelete(
-        data.ids, data.scope, data.log, version = data.version, commit = data.commit
-      ).flatMap { deleted =>
+        data.et, data.ids, data.scope, data.log, version = data.version, commit = data.commit
+      ).map { deleted =>
         if (data.commit) {
-          eventForwarder ! Delete(data.ids.map(data.et -> _))
-          searchIndexer.handle.clearIds(data.ids: _*).map { _ =>
-            Redirect(controllers.tools.routes.Tools.batchDelete())
-              .flashing("success" -> Messages("admin.utils.batchDelete.done", deleted))
-          }
+          Redirect(controllers.tools.routes.Tools.batchDelete())
+            .flashing("success" -> Messages("admin.utils.batchDelete.done", deleted))
         } else {
-          immediate(
-            Redirect(controllers.tools.routes.Tools.batchDelete())
-              .flashing("success" -> Messages("admin.utils.batchDelete.dryRun", deleted))
-          )
+          Redirect(controllers.tools.routes.Tools.batchDelete())
+            .flashing("success" -> Messages("admin.utils.batchDelete.dryRun", deleted))
         }
       } recover {
         case e: InputDataError =>
@@ -370,39 +360,23 @@ case class Tools @Inject()(
     }
   }
 
-  private def updateMovedItems(ct: ContentTypes.Value, items: Seq[(String, String)], newUrls: Seq[(String, String)]): Future[Int] = {
-    val deleted = items.map(_._1)
-    val created = items.map(_._2)
-    val et = entityType(ct)
-    for {
-      // Delete the old IDs from the search engine...
-      _ <- indexer.clearIds(deleted: _*)
-      _ = eventForwarder ! Delete(deleted.map(et -> _))
-      // Index the new ones....
-      _ <- indexer.indexIds(created: _*)
-      _ = eventForwarder ! Create(created.map(et -> _))
-      // Add the 301s to the DB...
-      redirectCount <- appComponents.pageRelocator.addMoved(newUrls)
-    } yield redirectCount
-  }
-
-  private def updateFromCsv(ct: ContentTypes.Value, items: Seq[(String, String)], newUrls: Seq[(String, String)]): Future[Seq[(String, String)]] = {
-    updateMovedItems(ct, items, newUrls).map { count =>
+  private def addUrlRelocations(urlMap: Seq[(String, String)]): Future[Seq[(String, String)]] = {
+    appComponents.pageRelocator.addMoved(urlMap).map { count =>
       logger.info(s"Added $count redirects")
-      newUrls
+      urlMap
     }
   }
 
-  private def updateFromCsv(ct: ContentTypes.Value, src: Source[ByteString, _]): Future[Seq[(String, String)]] = {
+  private def addUrlRedirectsFromCsv(ct: ContentTypes.Value, src: Source[ByteString, _]): Future[Seq[(String, String)]] = {
     parseCsv(src)
       .collect { case f :: t :: _ => f -> t }
       .runWith(Sink.seq).flatMap { items =>
-      updateFromCsv(ct, items, remapUrlsFromPrefixes(items, urlPrefixes.prefixes(entityType(ct))))
-    }
+        addUrlRelocations(remapUrlsFromPrefixes(items, urlPrefixes.prefixes(entityType(ct))))
+      }
   }
 
-  private def updateFromCsv(ct: ContentTypes.Value, items: Seq[(String, String)]): Future[Seq[(String, String)]] =
-    updateFromCsv(ct, items, remapUrlsFromPrefixes(items, urlPrefixes.prefixes(entityType(ct))))
+  private def addUrlRedirectsForType(ct: ContentTypes.Value, items: Seq[(String, String)]): Future[Seq[(String, String)]] =
+    addUrlRelocations(remapUrlsFromPrefixes(items, urlPrefixes.prefixes(entityType(ct))))
 
 
   private def parseCsv[M](src: Source[ByteString, M], sep: Char = ','): Source[List[String], M] = {

--- a/modules/backend/src/main/scala/services/data/BatchResult.scala
+++ b/modules/backend/src/main/scala/services/data/BatchResult.scala
@@ -1,9 +1,29 @@
 package services.data
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.JsonConfiguration.Aux
+import play.api.libs.json.JsonNaming.SnakeCase
+import play.api.libs.json.{Format, Json, JsonConfiguration}
 
-case class BatchResult(created: Int, updated: Int, unchanged: Int, errors: Map[String, String])
+/**
+  * Results from a backend batch operation.
+  *
+  * FIXME: there is redundency between this class and the
+  * `IngestResult` class in the admin package that should
+  * be refactored out.
+  */
+case class BatchResult(
+  createdKeys: Map[String, Seq[String]] = Map.empty,
+  updatedKeys: Map[String, Seq[String]] = Map.empty,
+  unchangedKeys: Map[String, Seq[String]] = Map.empty,
+  errors: Map[String, String]
+) {
+  def hasDoneWork: Boolean = createdKeys.nonEmpty || updatedKeys.nonEmpty
+  def updated: Int = updatedKeys.map(_._2.size).sum
+  def created: Int = createdKeys.map(_._2.size).sum
+  def unchanged: Int = unchangedKeys.map(_._2.size).sum
+}
 
 object BatchResult {
+  implicit val config: Aux[Json.MacroOptions] = JsonConfiguration(SnakeCase)
   implicit val _format: Format[BatchResult] = Json.format[BatchResult]
 }

--- a/modules/backend/src/main/scala/services/data/DataServiceBuilder.scala
+++ b/modules/backend/src/main/scala/services/data/DataServiceBuilder.scala
@@ -106,18 +106,20 @@ trait DataService {
   /**
     * Rename a batch of items.
     *
+    * @param et      the target entity type
     * @param mapping a mapping of current global ID to new local identifier
     * @return a mapping of old global ID to new (regenerated) global ID
     */
-  def rename(mapping: Seq[(String, String)]): Future[Seq[(String, String)]]
+  def rename(et: EntityType.Value, mapping: Seq[(String, String)]): Future[Seq[(String, String)]]
 
   /**
     * Reparent a batch of items.
     *
+    * @param et      the target entity type
     * @param mapping a mapping of current global ID to new parent global ID
     * @return a mapping of old global ID to new (regenerated) global ID
     */
-  def reparent(mapping: Seq[(String, String)], commit: Boolean = false): Future[Seq[(String, String)]]
+  def reparent(et: EntityType.Value, mapping: Seq[(String, String)], commit: Boolean = false): Future[Seq[(String, String)]]
 
   /**
     * Scan for IDs that require regeneration across an entire item type,
@@ -133,24 +135,25 @@ trait DataService {
     * Scan for IDs that require regeneration within a given scope,
     * and optionally regenerate them.
     *
+    * @param et     the target entity type
     * @param scope  the scope ID
     * @param commit whether to commit changes
     * @return a mapping of old global ID to new (regenerated) global ID
     */
-  def regenerateIdsForScope(scope: String, tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]]
+  def regenerateIdsForScope(et: EntityType.Value, scope: String, tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]]
 
   /**
     * Check if the given items require ID regeneration and optionally regenerate them.
     *
+    * @param et     the target entity type
     * @param ids    the given items
     * @param commit whether to commit changes
     * @return a mapping of old global ID to new (regenerated) global ID
     */
-  def regenerateIds(ids: Seq[String], tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]]
+  def regenerateIds(et: EntityType.Value, ids: Seq[String], tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]]
 
   /**
     * Find and replace a text value for a given property across an entire entity type.
-    *
     *
     * @param ct       the parent content type
     * @param et       a specific entity type
@@ -166,9 +169,7 @@ trait DataService {
   /**
     * Delete a batch of items of the same type.
     *
-    * Note: this API does **NOT** propagate delete events. This must be
-    * done from the client.
-    *
+    * @param et      the target entity type
     * @param ids     a sequence of item IDs
     * @param scope   an optional item scope
     * @param logMsg  a log message
@@ -176,28 +177,24 @@ trait DataService {
     * @param commit  whether to commit the changes
     * @return the number of items deleted
     */
-  def batchDelete(ids: Seq[String], scope: Option[String], logMsg: String, version: Boolean, tolerant: Boolean = false, commit: Boolean = false): Future[Int]
+  def batchDelete(et: EntityType.Value, ids: Seq[String], scope: Option[String], logMsg: String, version: Boolean, tolerant: Boolean = false, commit: Boolean = false): Future[Int]
 
   /**
     * Update a batch of items via a stream of partial JSON bundles.
     *
-    * Note: this API does **NOT** propagate update events. This must be
-    * done from the client.
-    *
+    * @param et      the target entity type
     * @param data    partial model data a JSON stream
     * @param scope   the optional shared item scope
     * @param version whether to create pre-update versions of updated items
     * @param commit  whether to commit the changes
     * @return the number of items updated
     */
-  def batchUpdate(data: Source[JsValue, _], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult]
+  def batchUpdate(et: EntityType.Value, data: Source[JsValue, _], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult]
 
   /**
     * Update a batch of items.
     *
-    * Note: this API does **NOT** propagate update events. This must be
-    * done from the client.
-    *
+    * @param et      the target entity type
     * @param data    the model data
     * @param scope   the optional shared item scope
     * @param version whether to create pre-update versions of updated items
@@ -205,7 +202,7 @@ trait DataService {
     * @tparam T the generic model data type
     * @return the number of items updated
     */
-  def batchUpdate[T: Writable](data: Seq[T], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult]
+  def batchUpdate[T: Writable](et: EntityType.Value, data: Seq[T], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult]
 
   /**
     * Fetch any type of item by ID.

--- a/modules/backend/src/main/scala/services/data/WsDataService.scala
+++ b/modules/backend/src/main/scala/services/data/WsDataService.scala
@@ -128,7 +128,6 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
     val entityType = Resource[MT].entityType
     val url = enc(typeBaseUrl, entityType, id)
     val callF = userCall(url)
-      .withQueryString(accessors.map(a => ACCESSOR_PARAM -> a): _*)
       .withQueryString(unpack(params): _*)
       .withHeaders(msgHeader(logMsg): _*)
       .post(Json.toJson(item)(Writable[T]._format))
@@ -291,16 +290,16 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
   }
 
   override def promote[MT: Resource](id: String): Future[MT] =
-    userCall(enc(genericItemUrl, id, "promote")).post().flatMap(itemResponse(id, _))
+    userCall(enc(genericItemUrl, id, "promote")).post().flatMap(updateItemResponse(id, _))
 
   override def removePromotion[MT: Resource](id: String): Future[MT] =
-    userCall(enc(genericItemUrl, id, "promote")).delete().flatMap(itemResponse(id, _))
+    userCall(enc(genericItemUrl, id, "promote")).delete().flatMap(updateItemResponse(id, _))
 
   override def demote[MT: Resource](id: String): Future[MT] =
-    userCall(enc(genericItemUrl, id, "demote")).post().flatMap(itemResponse(id, _))
+    userCall(enc(genericItemUrl, id, "demote")).post().flatMap(updateItemResponse(id, _))
 
   override def removeDemotion[MT: Resource](id: String): Future[MT] =
-    userCall(enc(genericItemUrl, id, "demote")).delete().flatMap(itemResponse(id, _))
+    userCall(enc(genericItemUrl, id, "demote")).delete().flatMap(updateItemResponse(id, _))
 
   override def links[A: Readable](id: String): Future[Page[A]] = {
     val pageParams = PageParams.empty.withoutLimit
@@ -736,19 +735,22 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
       .map(_.map(r => r.copy(_3 = r._3.toInt)))
   }
 
-  override def rename(mapping: Seq[(String, String)]): Future[Seq[(String, String)]] = {
+  override def rename(et: EntityType.Value, mapping: Seq[(String, String)]): Future[Seq[(String, String)]] = {
+    val commit = true
     val url = enc(baseUrl, "tools", "rename")
     userCall(url)
-      .withQueryString("commit" -> true.toString)
+      .withQueryString("commit" -> commit.toString)
       .post(Json.toJson(mapping))
       .map(r => checkErrorAndParse[Seq[(String, String)]](r, Some(url)))
+      .flatMap(r => handleRename(et, commit, r))
   }
 
-  override def reparent(mapping: Seq[(String, String)], commit: Boolean = false): Future[Seq[(String, String)]] = {
+  override def reparent(et: EntityType.Value, mapping: Seq[(String, String)], commit: Boolean = false): Future[Seq[(String, String)]] = {
     val url = enc(baseUrl, "tools", "reparent")
     userCall(url).withQueryString("commit" -> commit.toString)
       .post(Json.toJson(mapping))
       .map(r => checkErrorAndParse[Seq[(String, String)]](r, Some(url)))
+      .flatMap(r => handleRename(et, commit, r))
   }
 
   override def regenerateIdsForType(ct: ContentTypes.Value, tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]] = {
@@ -757,40 +759,45 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
       .withTimeout(config.get[Duration]("ehri.admin.bulkOperations.timeout"))
       .post()
       .map(r => checkErrorAndParse[Seq[(String, String)]](r, Some(url)))
+      .flatMap(r => handleRename(EntityType.withName(ct.toString), commit, r))
   }
 
-  override def regenerateIdsForScope(scope: String, tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]] = {
+  override def regenerateIdsForScope(et: EntityType.Value, scope: String, tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]] = {
     val url = enc(baseUrl, "tools", "regenerate-ids-for-scope", scope)
     userCall(url).withQueryString("tolerant" -> tolerant.toString, "commit" -> commit.toString)
       .withTimeout(config.get[Duration]("ehri.admin.bulkOperations.timeout"))
       .post()
       .map(r => checkErrorAndParse[Seq[(String, String)]](r, Some(url)))
+      .flatMap(r => handleRename(et, commit, r))
   }
 
-  override def regenerateIds(ids: Seq[String], tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]] = {
+  override def regenerateIds(et: EntityType.Value, ids: Seq[String], tolerant: Boolean = false, commit: Boolean = false): Future[Seq[(String, String)]] = {
     val url = enc(baseUrl, "tools", "regenerate-ids")
     userCall(url)
       .withQueryString("tolerant" -> tolerant.toString, "commit" -> commit.toString)
       .post(Json.toJson(ids.map(id => Seq(id))))
       .map(r => checkErrorAndParse[Seq[(String, String)]](r, Some(url)))
+      .flatMap(r => handleRename(et, commit, r))
   }
 
   override def findReplace(ct: ContentTypes.Value, et: EntityType.Value, property: String, from: String, to: String, commit: Boolean, logMsg: Option[String]): Future[Seq[(String, String, String)]] = {
     val url = enc(baseUrl, "tools", "find-replace")
-    val out = userCall(url)
+    val outF = userCall(url)
       .withHeaders(msgHeader(logMsg): _*)
       .withQueryString("type" -> ct.toString, "subtype" -> et.toString,
         "property" -> property, "commit" -> commit.toString)
       .post(Map("from" -> Seq(from), "to" -> Seq(to)))
       .map(r => checkErrorAndParse[Seq[(String, String, String)]](r, Some(url)))
-    out.map { list =>
-      val toUpdate = list.map { case (id, _, _) => EntityType.withName(ct.toString) -> id }
-      eventHandler.handleUpdate(toUpdate: _*)
-      list
+    outF.flatMap { list =>
+      if (commit) {
+        val toUpdate = list.map { case (id, _, _) => EntityType.withName(ct.toString) -> id }
+        eventHandler.handleUpdate(toUpdate: _*)
+        invalidate(toUpdate.map(_._2)).map(_ => list)
+      } else immediate(list)
     }
   }
 
-  override def batchUpdate(data: Source[JsValue, _], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult] = {
+  override def batchUpdate(et: EntityType.Value, data: Source[JsValue, _], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult] = {
     val url = enc(baseUrl, "batch", "update")
     val src: Source[ByteString, _] = data
       .map(js => ByteString.fromArray(Json.toBytes(js)))
@@ -806,9 +813,10 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
       .withMethod(HttpVerbs.PUT)
       .execute()
       .map(r => checkErrorAndParse[BatchResult](r, Some(url)))
+      .flatMap(r => handleBatchEvents(et, commit, r))
   }
 
-  override def batchUpdate[T: Writable](data: Seq[T], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult] = {
+  override def batchUpdate[T: Writable](et: EntityType.Value, data: Seq[T], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult] = {
     implicit val _writes: Writes[T] = Writable[T]._format
     val url = enc(baseUrl, "batch", "update")
     userCall(url).withQueryString(
@@ -818,9 +826,10 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
       .withQueryString(scope.toSeq.map(s => "scope" -> s): _*)
       .put(Json.toJson(data))
       .map(r => checkErrorAndParse[BatchResult](r, Some(url)))
+      .flatMap(r => handleBatchEvents(et, commit, r))
   }
 
-  override def batchDelete(ids: Seq[String], scope: Option[String], logMsg: String, version: Boolean, tolerant: Boolean = false, commit: Boolean = false): Future[Int] = {
+  override def batchDelete(et: EntityType.Value, ids: Seq[String], scope: Option[String], logMsg: String, version: Boolean, tolerant: Boolean = false, commit: Boolean = false): Future[Int] = {
     val url = enc(baseUrl, "batch", "delete")
     val callF = userCall(url).withQueryString(
         "version" -> version.toString,
@@ -831,7 +840,11 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
       .withQueryString(scope.toSeq.map(s => "scope" -> s): _*)
       .post(Json.toJson(ids.map(id => Seq(id))))
       .map(r => checkErrorAndParse[Int](r, Some(url)))
-    for (count <- callF; _ <- invalidate(ids)) yield count
+    for {
+      count <- callF
+      _ <- invalidate(ids) if count > 0 && commit
+      _ = eventHandler.handleDelete(ids.map(et -> _): _*) if count > 0 && commit
+    } yield count
   }
 
   // Helpers
@@ -847,7 +860,7 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
       }.getOrElse(-1L)
     }
 
-  private def itemResponse[MT: Resource](id: String, response: WSResponse): Future[MT] = {
+  private def updateItemResponse[MT: Resource](id: String, response: WSResponse): Future[MT] = {
     val res = Resource[MT]
     val item: MT = checkErrorAndParse(response)(res._reads)
     eventHandler.handleUpdate(res.entityType -> id)
@@ -874,6 +887,26 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
       .map { bytes => Json.parse(bytes.utf8String).validate[A](reader._reads) }
       .collect { case JsSuccess(item, _) => item}
     )).flatMapConcat(identity)
+  }
+
+  private def handleBatchEvents(et: EntityType.Value, commit: Boolean, batchRes: BatchResult) = {
+    if (batchRes.hasDoneWork && commit) {
+      val createdIds = batchRes.updatedKeys.values.toSeq.flatten
+      val updatedIds = batchRes.createdKeys.values.toSeq.flatten
+      eventHandler.handleCreate(createdIds.map(et -> _): _*)
+      eventHandler.handleUpdate(updatedIds.map(et -> _): _*)
+      invalidate(createdIds ++ updatedIds).map(_ => batchRes)
+    } else immediate(batchRes)
+  }
+
+  private def handleRename(et: EntityType.Value, commit: Boolean, mapping: Seq[(String, String)]): Future[Seq[(String, String)]] = {
+    if (commit) {
+      val deleted = mapping.map(_._1)
+      val created = mapping.map(_._2)
+      eventHandler.handleDelete(deleted.map(et -> _): _*)
+      eventHandler.handleCreate(created.map(et -> _): _*)
+      invalidate(deleted ++ created).map(_ => mapping)
+    } else immediate(mapping)
   }
 }
 

--- a/test/actors/cleanup/CleanupRunnerManagerSpec.scala
+++ b/test/actors/cleanup/CleanupRunnerManagerSpec.scala
@@ -2,14 +2,12 @@ package actors.cleanup
 
 import actors.LongRunningJob
 import actors.cleanup.CleanupRunner.CleanupJob
-import org.apache.pekko.actor.{ActorContext, ActorRef, Props}
-import com.google.inject.name.Names
 import controllers.datasets.CleanupConfirmation
 import helpers.IntegrationTestRunner
 import mockdata.adminUserProfile
 import models._
+import org.apache.pekko.actor.{ActorContext, Props}
 import play.api.i18n.{Lang, Messages, MessagesApi}
-import play.api.inject.{BindingKey, QualifierInstance}
 import play.api.{Application, Configuration}
 import services.data.DataUser
 import services.ingest.{ImportLogService, IngestService}
@@ -20,8 +18,6 @@ class CleanupRunnerManagerSpec extends IntegrationTestRunner {
   implicit private def config(implicit app: Application): Configuration = app.injector.instanceOf[Configuration]
   private def logService(implicit app: Application): ImportLogService = app.injector.instanceOf[ImportLogService]
   private def importService(implicit app: Application): IngestService = app.injector.instanceOf[IngestService]
-  private def eventForwarder(implicit app: Application): ActorRef = app.injector.instanceOf[ActorRef](
-    BindingKey(classOf[ActorRef], Some(QualifierInstance(Names.named("event-forwarder")))))
   implicit def messagesApi(implicit app: Application): MessagesApi = app.injector.instanceOf[MessagesApi]
   implicit def messages(implicit app: Application): Messages = messagesApi.preferred(Seq(Lang.defaultLang))
 
@@ -37,7 +33,7 @@ class CleanupRunnerManagerSpec extends IntegrationTestRunner {
       val cleanupConfirmation = CleanupConfirmation("Delete it")
       val cleanupJob: CleanupJob = CleanupJob("r1", 1, jobId, cleanupConfirmation.msg)
 
-      val init = (context: ActorContext) => context.actorOf(Props(CleanupRunner(dataApi, logService, importService, eventForwarder)))
+      val init = (context: ActorContext) => context.actorOf(Props(CleanupRunner(dataApi, logService, importService)))
       val manager = system.actorOf(Props(CleanupRunnerManager(cleanupJob, init)))
 
       manager ! self // initial subscriber should start harvesting
@@ -56,7 +52,7 @@ class CleanupRunnerManagerSpec extends IntegrationTestRunner {
       val cleanupConfirmation = CleanupConfirmation("Delete it")
       val cleanupJob: CleanupJob = CleanupJob("r1", 1, jobId, cleanupConfirmation.msg)
 
-      val init = (context: ActorContext) => context.actorOf(Props(CleanupRunner(dataApi, logService, importService, eventForwarder)))
+      val init = (context: ActorContext) => context.actorOf(Props(CleanupRunner(dataApi, logService, importService)))
       val manager = system.actorOf(Props(CleanupRunnerManager(cleanupJob, init)))
 
       manager ! self // initial subscriber should start harvesting

--- a/test/integration/admin/ToolsSpec.scala
+++ b/test/integration/admin/ToolsSpec.scala
@@ -43,6 +43,7 @@ class ToolsSpec extends IntegrationTestRunner with FakeMultipartUpload {
     }
 
     "perform ID regeneration" in new ITestApp {
+      val before = indexEventBuffer.size
       val result = FakeRequest(toolRoutes.regenerateIdsForType(ContentTypes.DocumentaryUnit))
           .withHeaders("X-REQUESTED-WITH" -> "xmlhttprequest")
         .withUser(privilegedUser)
@@ -68,9 +69,12 @@ class ToolsSpec extends IntegrationTestRunner with FakeMultipartUpload {
       status(rename) must_== OK
       contentAsString(rename) must contain(
         controllers.portal.routes.DocumentaryUnits.browse("nl-r1-c1-c2-c3").url)
+      // For each affected item we want a pair of delete and create events:
+      indexEventBuffer.size must_== before + 8
     }
 
     "allow batch renaming items" in new ITestApp {
+      val before = indexEventBuffer.size
       val f = File.createTempFile("/upload", ".csv")
       f.deleteOnExit()
       FileUtils.writeStringToFile(f, "c1,new-c1\nc4,new-c4", "UTF-8")
@@ -92,12 +96,14 @@ class ToolsSpec extends IntegrationTestRunner with FakeMultipartUpload {
         from must_== "/admin/units/c4"
         to must_== "/admin/units/nl-r1-new_c4"
       }
+      indexEventBuffer.size must_== before + 4
       // Clear the mutable buffer to prevent redirects
       // interfering in other tests
       movedPages.clear()
     }
 
     "allow batch reparenting items" in new ITestApp {
+      val before = indexEventBuffer.size
       val f = File.createTempFile("/upload", ".csv")
       f.deleteOnExit()
       FileUtils.writeStringToFile(f, "c4,c1", "UTF-8")
@@ -115,6 +121,9 @@ class ToolsSpec extends IntegrationTestRunner with FakeMultipartUpload {
         from must_== "/units/c4"
         to must_== "/units/nl-r1-c1-c4"
       }
+      // we should have one more delete event and one more create event
+      indexEventBuffer.size must_== before + 2
+
       // Clear the mutable buffer to prevent redirects
       // interfering in other tests
       movedPages.clear()
@@ -122,7 +131,7 @@ class ToolsSpec extends IntegrationTestRunner with FakeMultipartUpload {
 
     "handle find/replace correctly" in new ITestApp {
       import models.FindReplaceTask._
-
+      val before = indexEventBuffer.size
       val data: Map[String,Seq[String]] = Map(
         PARENT_TYPE -> Seq(Entities.REPOSITORY),
         SUB_TYPE -> Seq(Entities.REPOSITORY_DESCRIPTION),
@@ -148,10 +157,14 @@ class ToolsSpec extends IntegrationTestRunner with FakeMultipartUpload {
       status(replace) must_== SEE_OTHER
       flash(replace) must_== Flash(
         Map("success" -> message("admin.utils.findReplace.done", 1)(messagesApi)))
+
+      // There should be a single extra index event in the buffer
+      indexEventBuffer.size must_== before + 1
     }
 
 
     "handle batch delete correctly" in new ITestApp {
+      val before = indexEventBuffer.size
       import models.BatchDeleteTask._
 
       val data: Map[String,Seq[String]] = Map(
@@ -171,6 +184,7 @@ class ToolsSpec extends IntegrationTestRunner with FakeMultipartUpload {
       status(del) must_== SEE_OTHER
       flash(del) must_== Flash(
         Map("success" -> message("admin.utils.batchDelete.done", 2)(messagesApi)))
+      indexEventBuffer.size must_== before + 2
     }
 
     "allow creating arbitrary redirects" in new ITestApp {

--- a/test/services/data/WsDataServiceSpec.scala
+++ b/test/services/data/WsDataServiceSpec.scala
@@ -299,12 +299,15 @@ class WsDataServiceSpec extends IntegrationTestRunner {
 
   "Batch operations" should {
     "delete items as a batch" in new ITestApp {
-      val count = await(testBackend.batchDelete(Seq("c1", "c4"),
+      val before = indexEventBuffer.size
+      val count = await(testBackend.batchDelete(EntityType.DocumentaryUnit, Seq("c1", "c4"),
         scope = Some("r1"), version = true, commit = true, logMsg = "test"))
       count must_== 2
+      indexEventBuffer.size must_== before + 2
     }
 
     "update items via a JSON stream" in new ITestApp {
+      val before = indexEventBuffer.size
       val src = Source(List(Json.obj(
         "id" -> "r1",
         "type" -> "Repository",
@@ -315,9 +318,10 @@ class WsDataServiceSpec extends IntegrationTestRunner {
         "data" -> Json.obj("longitude" -> 0.5, "latitude" -> 0.5)
       )))
 
-      val log = await(testBackend.batchUpdate(src, scope = None, version = true,
+      val log = await(testBackend.batchUpdate(EntityType.Repository, src, scope = None, version = true,
         commit = true, logMsg = "test"))
       log.updated must_== 2
+      indexEventBuffer.size must_== before + 2
     }
   }
 

--- a/test/services/search/MockSearchIndexMediator.scala
+++ b/test/services/search/MockSearchIndexMediator.scala
@@ -14,43 +14,43 @@ case class MockSearchIndexMediatorHandle(eventBuffer: collection.mutable.ListBuf
 
   private val logger = Logger(classOf[MockSearchIndexMediatorHandle])
 
-  def indexIds(ids: String*): Future[Unit] = {
+  def indexIds(ids: String*): Future[Unit] = synchronized {
     ids.foreach(id => eventBuffer += id)
     logger.debug(s"Indexing: $ids")
     Future.successful(())
   }
 
-  def indexTypes(entityTypes: Seq[EntityType.Value]): Future[Unit] = {
+  def indexTypes(entityTypes: Seq[EntityType.Value]): Future[Unit] = synchronized {
     eventBuffer += entityTypes.toString
     logger.debug(s"Indexing: $entityTypes")
     Future.successful(())
   }
 
-  def indexChildren(entityType: EntityType.Value, id: String): Future[Unit] = {
+  def indexChildren(entityType: EntityType.Value, id: String): Future[Unit] = synchronized {
     eventBuffer += id
     logger.debug(s"Indexing children: $entityType -> $id")
     Future.successful(())
   }
 
-  def clearAll(): Future[Unit] = {
+  def clearAll(): Future[Unit] = synchronized {
     eventBuffer += "clear-all"
     logger.debug("Clearing entire index...")
     Future.successful(())
   }
 
-  def clearTypes(entityTypes: Seq[EntityType.Value]): Future[Unit] = {
+  def clearTypes(entityTypes: Seq[EntityType.Value]): Future[Unit] = synchronized {
     eventBuffer += "clear-types:" + entityTypes.toString
     logger.debug(s"Clearing entity types: $entityTypes")
     Future.successful(())
   }
 
-  def clearIds(ids: String*): Future[Unit] = {
+  def clearIds(ids: String*): Future[Unit] = synchronized {
     ids.foreach(id => eventBuffer += id)
     logger.debug(s"Clearing id: $ids")
     Future.successful(())
   }
 
-  def clearKeyValue(key: String, value: String): Future[Unit] = {
+  def clearKeyValue(key: String, value: String): Future[Unit] = synchronized {
     eventBuffer += "clear-key-value " + s"$key=$value"
     logger.debug(s"Clearing key-value: $key=$value")
     Future.successful(())


### PR DESCRIPTION
Previously this was the responsibility of the caller, which became quite confusing. Now, only the ingest API does its own event handling following an operation.