### PR TITLE
Add a language of material notes field for non-coercable data

### DIFF
--- a/modules/admin/app/views/admin/documentaryUnit/description.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/description.scala.html
@@ -35,8 +35,8 @@
     @descriptionSection(CONDITIONS_AREA) {
         @textValue(ACCESS_COND, desc.conditions.conditionsOfAccess)
         @textValue(REPROD_COND, desc.conditions.conditionsOfReproduction)
-
         @listValue(LANG_MATERIALS, desc.conditions.languageOfMaterials, transformFunc = s => views.Helpers.languageCodeToName(s))
+        @textValue(LANG_MATERIAL_NOTES, desc.conditions.languageOfMaterialNotes)
         @listValue(SCRIPT_MATERIALS, desc.conditions.scriptOfMaterials, transformFunc = s => views.Helpers.scriptCodeToName(s))
         @textValue(PHYSICAL_CHARS, desc.conditions.physicalCharacteristics)
         @textListValue(FINDING_AIDS, desc.conditions.findingAids)

--- a/modules/admin/app/views/admin/documentaryUnit/descriptionForm.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/descriptionForm.scala.html
@@ -54,6 +54,7 @@
             @textInput(desc, ACCESS_COND)
             @textInput(desc, REPROD_COND)
             @choiceInput(desc, LANG_MATERIALS, views.Helpers.languagePairList, attrs._multiple -> true, attrs._size -> 1)
+            @hiddenInput(desc(LANG_MATERIAL_NOTES))
             @choiceInput(desc, SCRIPT_MATERIALS, views.Helpers.scriptPairList, attrs._multiple -> true, attrs._size -> 1)
             @textInput(desc, PHYSICAL_CHARS)
             @inlineTextSet(desc, FINDING_AIDS, rows = 4)

--- a/modules/core/src/main/scala/models/DocumentaryUnitDescription.scala
+++ b/modules/core/src/main/scala/models/DocumentaryUnitDescription.scala
@@ -39,6 +39,7 @@ case class IsadGConditions(
   conditionsOfAccess: Option[String] = None,
   conditionsOfReproduction: Option[String] = None,
   languageOfMaterials: Seq[String] = Nil,
+  languageOfMaterialNotes: Option[String] = None,
   scriptOfMaterials: Seq[String] = Nil,
   physicalCharacteristics: Option[String] = None,
   findingAids: Seq[String] = Nil
@@ -98,6 +99,7 @@ object DocumentaryUnitDescriptionF {
       (__ \ ACCESS_COND).formatNullable[String] and
       (__ \ REPROD_COND).formatNullable[String] and
       (__ \ LANG_MATERIALS).formatSeqOrSingle[String] and
+      (__ \ LANG_MATERIAL_NOTES).formatNullable[String] and
       (__ \ SCRIPT_MATERIALS).formatSeqOrSingle[String] and
       (__ \ PHYSICAL_CHARS).formatNullable[String] and
       (__ \ FINDING_AIDS).formatSeqOrSingle[String]
@@ -169,7 +171,7 @@ object DocumentaryUnitDescription {
   import models.IsadG._
   import utils.EnumUtils.enumMapping
 
-  val form = Form(
+  val form: Form[DocumentaryUnitDescriptionF] = Form(
     mapping(
       ISA -> ignored(EntityType.DocumentaryUnitDescription),
       ID -> optional(nonEmptyText),
@@ -201,6 +203,7 @@ object DocumentaryUnitDescription {
         ACCESS_COND -> optional(text),
         REPROD_COND -> optional(text),
         LANG_MATERIALS -> seq(nonEmptyText),
+        LANG_MATERIAL_NOTES -> optional(text),
         SCRIPT_MATERIALS -> seq(nonEmptyText),
         PHYSICAL_CHARS -> optional(text),
         FINDING_AIDS -> seq(nonEmptyText)

--- a/modules/core/src/main/scala/models/IsadG.scala
+++ b/modules/core/src/main/scala/models/IsadG.scala
@@ -57,6 +57,7 @@ case object IsadG {
   val ACCESS_COND = "conditionsOfAccess"
   val REPROD_COND = "conditionsOfReproduction"
   val LANG_MATERIALS = "languageOfMaterial"
+  val LANG_MATERIAL_NOTES = "languageOfMaterialNotes"
   val SCRIPT_MATERIALS = "scriptOfMaterial"
   val PHYSICAL_CHARS = "physicalCharacteristics"
   val FINDING_AIDS = "findingAids"

--- a/modules/portal/app/views/documentaryUnit/details.scala.html
+++ b/modules/portal/app/views/documentaryUnit/details.scala.html
@@ -30,14 +30,20 @@
         <dt>@Messages("documentaryUnit.levelOfDescription")</dt>
         <dd>@translationOrCode("documentaryUnit.levelOfDescription", e)</dd>
     }
-    @if(desc.conditions.languageOfMaterials.nonEmpty) {
+    @if(desc.conditions.languageOfMaterials.nonEmpty || desc.conditions.languageOfMaterialNotes.exists(_.nonEmpty)) {
         <dt>@Messages("documentaryUnit.languageOfMaterials")</dt>
         <dd class="item-meta-languages">
-            <ul>
-                @desc.conditions.languageOfMaterials.map { l =>
-                    <li>@views.Helpers.languageCodeToName(l)</li>
+            @if(desc.conditions.languageOfMaterials.nonEmpty) {
+                <ul>
+                    @desc.conditions.languageOfMaterials.map { l =>
+                        <li>@views.Helpers.languageCodeToName(l)</li>
+                    }
+                </ul>
+            } else {
+                @desc.conditions.languageOfMaterialNotes.map { notes =>
+                    <span title="@notes">@views.Helpers.ellipsize(notes, 60)</span>
                 }
-            </ul>
+            }
         </dd>
     }
     @if(desc.conditions.scriptOfMaterials.nonEmpty) {


### PR DESCRIPTION
This is displayed as a fallback if there are no codes.