### PR TITLE
Enable SSE stream replay via query string last-event-id

### DIFF
--- a/modules/admin/app/controllers/admin/ServerSentEvents.scala
+++ b/modules/admin/app/controllers/admin/ServerSentEvents.scala
@@ -1,7 +1,7 @@
 package controllers.admin
 
 import controllers.AppComponents
-import controllers.admin.ServerSentEvents.LAST_EVENT_ID_HEADER
+import controllers.admin.ServerSentEvents.LAST_EVENT_ID_PARAM
 import controllers.base.AdminController
 import org.apache.pekko.actor.{ActorRef, ActorSystem}
 import org.apache.pekko.stream.scaladsl.{BroadcastHub, Keep, Source}
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 object ServerSentEvents {
-  val LAST_EVENT_ID_HEADER = "Last-Event-Id"
+  val LAST_EVENT_ID_PARAM = "Last-Event-Id"
 }
 
 /**
@@ -61,7 +61,10 @@ case class ServerSentEvents @Inject()(
   def lifecycle: Action[AnyContent] = Action { implicit request =>
 
     // If we have a replay header, fetch an initial stream from the store
-    val lastInsertId: Option[String] = request.headers.get(LAST_EVENT_ID_HEADER).filter(_.trim.nonEmpty)
+    val lastInsertId: Option[String] = request.headers
+      .get(LAST_EVENT_ID_PARAM)
+      .orElse(request.getQueryString(LAST_EVENT_ID_PARAM))
+      .filter(_.trim.nonEmpty)
     val replay: Future[Seq[EventSource.Event]] = lastInsertId.map { id =>
       eventStore.get(id).map(_.map(ev => EventSource.Event(ev.data, id = Some(ev.id.toString), name = ev.name)))
     }.getOrElse(Future.successful(Seq.empty[EventSource.Event]))

--- a/test/integration/admin/ServerSentEventsSpec.scala
+++ b/test/integration/admin/ServerSentEventsSpec.scala
@@ -58,5 +58,27 @@ class ServerSentEventsSpec extends IntegrationTestRunner with FakeMultipartUploa
       events.head must contain(s"event: hello-world")
       events.head must contain(s"id: ${ids.head}")
     }
+
+    "check event stream supports replay via query param" in new ITestServer() {
+      val eventStore = app.injector.instanceOf[ApplicationEventService]
+      private val ids = 1.to(3).map(_ => GUID.v7().toUUID)
+      await(eventStore.save(
+        ids.map(id => ApplicationEvent(id, "test", Some("hello-world")))
+      ))
+
+      val req = client.url(s"http://localhost:${this.port}${controllers.admin.routes.ServerSentEvents.lifecycle()}")
+        .withHttpHeaders("Accept" -> MimeTypes.EVENT_STREAM)
+        .withQueryStringParameters( "Last-Event-Id" -> ids.head.toString)
+        .stream()
+
+      val resp = await(req)
+      resp.status must_== OK
+      resp.contentType must_== MimeTypes.EVENT_STREAM
+
+      val events: Seq[String] = await(resp.bodyAsSource.take(6).map(_.utf8String).runWith(Sink.seq))
+      events.head must contain("data: test")
+      events.head must contain(s"event: hello-world")
+      events.head must contain(s"id: ${ids.head}")
+    }
   }
 }


### PR DESCRIPTION
In addition to header. This should be easier for some tools to handle.