### PR TITLE
Fix for Apache reverse proxy preventing encoded slashes in ARK PIDs

### DIFF
--- a/modules/api/app/controllers/api/v1/ApiV1.scala
+++ b/modules/api/app/controllers/api/v1/ApiV1.scala
@@ -426,6 +426,11 @@ case class ApiV1 @Inject()(
       } recoverWith errorHandler
     }
 
+  def fetchArk(ark: String, fields: Seq[FieldFilter]): Action[AnyContent] = JsonApiAction.async { implicit request =>
+    // Internal redirect to handle the slashes in an ark URL.
+    fetch(ark, fields, pid = true).apply(request)
+  }
+
   def searchIn(id: String, `type`: Seq[ApiEntity.Value], params: SearchParams, paging: PageParams, fields: Seq[FieldFilter], facets: ApiFacets): Action[AnyContent] =
     JsonApiAction.async { implicit request =>
       implicit val writer: Writes[Model] = modelWriter(fields)

--- a/modules/api/conf/api.routes
+++ b/modules/api/conf/api.routes
@@ -3,6 +3,7 @@
 GET         /                 @controllers.api.ApiHome.index()
 GET        /v1                @controllers.api.v1.ApiV1Home.index()
 GET        /v1/search         @controllers.api.v1.ApiV1.search(`type`: Seq[models.api.v1.ApiEntity.Value] ?= Seq.empty, params: services.search.SearchParams ?= services.search.SearchParams.empty, paging: utils.PageParams ?= utils.PageParams.empty, fields: Seq[utils.FieldFilter] ?= Seq.empty, facets: models.api.v1.ApiFacets ?= models.api.v1.ApiFacets.empty)
+GET        /v1/$id<ark:.+>    @controllers.api.v1.ApiV1.fetchArk(id: String, fields: Seq[utils.FieldFilter] ?= Seq.empty)
 GET        /v1/:id            @controllers.api.v1.ApiV1.fetch(id: String, fields: Seq[utils.FieldFilter] ?= Seq.empty, pid: Boolean ?= false)
 GET        /v1/:id/search     @controllers.api.v1.ApiV1.searchIn(id: String, `type`: Seq[models.api.v1.ApiEntity.Value] ?= Seq.empty, params: services.search.SearchParams ?= services.search.SearchParams.empty, paging: utils.PageParams ?= utils.PageParams.empty, fields: Seq[utils.FieldFilter] ?= Seq.empty, facets: models.api.v1.ApiFacets ?= models.api.v1.ApiFacets.empty)
 GET        /v1/:id/related    @controllers.api.v1.ApiV1.related(id: String, `type`: Seq[models.api.v1.ApiEntity.Value] ?= Seq.empty, params: services.search.SearchParams ?= services.search.SearchParams.empty, paging: utils.PageParams ?= utils.PageParams.empty, fields: Seq[utils.FieldFilter] ?= Seq.empty, facets: models.api.v1.ApiFacets ?= models.api.v1.ApiFacets.empty)

--- a/test/integration/api/v1/ApiV1Spec.scala
+++ b/test/integration/api/v1/ApiV1Spec.scala
@@ -15,7 +15,7 @@ import utils.FieldFilter
 
 
 class ApiV1Spec extends IntegrationTestRunner {
-  import mockdata.{privilegedUser}
+  import mockdata.privilegedUser
   private val apiRoutes = controllers.api.v1.routes.ApiV1
   private val docRoutes = controllers.units.routes.DocumentaryUnits
 
@@ -81,7 +81,7 @@ class ApiV1Spec extends IntegrationTestRunner {
 
     "allow fetching items by prefixed PID" in new ITestApp(
         specificConfig = Map("ehri.portal.arks.display" -> true, "ehri.portal.arks.urlPrefix" -> "https://arks.org/ark:12345/x1")) {
-      val fetch = FakeRequest(apiRoutes.fetch("ark:12345/p0c4-12345678", pid = true)).call()
+      val fetch = FakeRequest(apiRoutes.fetchArk("ark:12345/p0c4-12345678")).call()
       status(fetch) must_== OK
       validateJson(contentAsJson(fetch))
       contentAsJson(fetch) \ "data" \ "meta" \ "pid" must_== JsDefined(JsString("c4-12345678"))


### PR DESCRIPTION
This adds a new route specifically for the ARK pattern, and forwards it internally to the relevent Play route.

FIXME: the docs don't allow putting in an ARK due to the encoding they do on entered data.