### PR TITLE
Add support for JSON imports (to be added soon to backend)

### DIFF
--- a/modules/admin/app/controllers/datasets/ImportConfigs.scala
+++ b/modules/admin/app/controllers/datasets/ImportConfigs.scala
@@ -88,6 +88,7 @@ case class ImportConfigs @Inject()(
       val taskType = if (dataset.fonds.isDefined && request.body.files.isEmpty && dataset.sync)
         IngestDataType.EadSync
       else if (dataset.contentType.contains("text/csv")) IngestDataType.Csv
+      else if (dataset.contentType.contains("application/json")) IngestDataType.Json
       else IngestDataType.Ead
 
       // Field separator for tabular datasets: only CSV supported at the moment

--- a/modules/admin/app/services/ingest/IngestService.scala
+++ b/modules/admin/app/services/ingest/IngestService.scala
@@ -17,6 +17,7 @@ object IngestService {
     val EadSync = Value("ead-sync")
     val Skos = Value("skos")
     val Csv = Value("csv")
+    val Json = Value("json")
 
     implicit val binder: QueryStringBindable[IngestDataType.Value] =
       utils.binders.queryStringBinder(this)

--- a/modules/admin/app/services/ingest/WSIngestService.scala
+++ b/modules/admin/app/services/ingest/WSIngestService.scala
@@ -62,6 +62,7 @@ case class WSIngestService @Inject()(
     case IngestDataType.Eac => EntityType.HistoricalAgent
     case IngestDataType.Ead | IngestDataType.EadSync => EntityType.DocumentaryUnit
     case IngestDataType.Csv => EntityType.DocumentaryUnit
+    case IngestDataType.Json => EntityType.DocumentaryUnit
     case IngestDataType.Skos => EntityType.Concept
   }
 


### PR DESCRIPTION
JSON imports have the same very restricted format as CSV imports currently, but this is more like an intermediate format and we will soon add converters to map to them from other data types